### PR TITLE
Update build scripts and README to include versioning in release arti…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,26 @@ install-cross-deps:
 package-release: cross-build-armv7 cross-build-arm64 build-macos
 	@echo "Creating release packages..."
 	@mkdir -p dist
-	@cd target/armv7-unknown-linux-gnueabihf/release && \
-		tar -czf phaeton-armv7-unknown-linux-gnueabihf.tar.gz phaeton && \
-		mv phaeton-armv7-unknown-linux-gnueabihf.tar.gz ../../../dist/
-	@cd target/aarch64-unknown-linux-gnu/release && \
-		tar -czf phaeton-aarch64-unknown-linux-gnu.tar.gz phaeton && \
-		mv phaeton-aarch64-unknown-linux-gnu.tar.gz ../../../dist/
-	@cd target/release && \
-		tar -czf phaeton-macos-arm64.tar.gz phaeton && \
-		mv phaeton-macos-arm64.tar.gz ../../../dist/
-	@echo "Release packages created in dist/ directory"
+	@VERSION=$${PHAETON_VERSION:-$$(grep -m1 '^version\s*=\s*"' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')} ; \\
+	if git describe --tags --abbrev=0 >/dev/null 2>&1 ; then \\
+	  TAG=$$(git describe --tags --abbrev=0 2>/dev/null || true) ; \\
+	  case "$$TAG" in \\
+	    v$$VERSION*) VERSION=$${TAG#v} ;; \\
+	  esac ; \\
+	fi ; \\
+	cd target/armv7-unknown-linux-gnueabihf/release && \\
+		tar -czf phaeton-v$$VERSION-armv7-unknown-linux-gnueabihf.tar.gz phaeton && \\
+		mv phaeton-v$$VERSION-armv7-unknown-linux-gnueabihf.tar.gz ../../../dist/ ; \\
+	cd - >/dev/null ; \\
+	cd target/aarch64-unknown-linux-gnu/release && \\
+		tar -czf phaeton-v$$VERSION-aarch64-unknown-linux-gnu.tar.gz phaeton && \\
+		mv phaeton-v$$VERSION-aarch64-unknown-linux-gnu.tar.gz ../../../dist/ ; \\
+	cd - >/dev/null ; \\
+	cd target/release && \\
+		tar -czf phaeton-v$$VERSION-macos-arm64.tar.gz phaeton && \\
+		mv phaeton-v$$VERSION-macos-arm64.tar.gz ../../../dist/ ; \\
+	cd - >/dev/null ; \\
+	echo "Release packages created in dist/ directory (version $$VERSION)"
 
 # Security audit
 audit:

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ A high-performance Rust implementation of the Alfen EV charger driver for Victro
 
 Grab the latest binaries from [Releases](https://github.com/your-org/phaeton/releases):
 
-- **Cerbo GX (ARMv7)**: `phaeton-armv7-unknown-linux-gnueabihf.tar.gz`
-- **Linux ARM64**: `phaeton-aarch64-unknown-linux-gnu.tar.gz`
-- **macOS ARM64**: `phaeton-macos-arm64.tar.gz`
+- **Cerbo GX (ARMv7)**: `phaeton-v<version>-armv7-unknown-linux-gnueabihf.tar.gz`
+- **Linux ARM64**: `phaeton-v<version>-aarch64-unknown-linux-gnu.tar.gz`
+- **macOS ARM64**: `phaeton-v<version>-macos-arm64.tar.gz`
 
 Verify checksums (Linux):
 
 ```bash
 curl -L -O https://github.com/your-org/phaeton/releases/download/<tag>/SHA256SUMS
-curl -L -O https://github.com/your-org/phaeton/releases/download/<tag>/phaeton-<artifact>.tar.gz
+curl -L -O https://github.com/your-org/phaeton/releases/download/<tag>/phaeton-v<version>-<artifact>.tar.gz
 sha256sum -c SHA256SUMS
 ```
 
@@ -40,15 +40,15 @@ Verify on macOS:
 
 ```bash
 curl -L -O https://github.com/your-org/phaeton/releases/download/<tag>/SHA256SUMS
-curl -L -O https://github.com/your-org/phaeton/releases/download/<tag>/phaeton-macos-arm64.tar.gz
-shasum -a 256 phaeton-macos-arm64.tar.gz
-grep phaeton-macos-arm64.tar.gz SHA256SUMS
+curl -L -O https://github.com/your-org/phaeton/releases/download/<tag>/phaeton-v<version>-macos-arm64.tar.gz
+shasum -a 256 phaeton-v<version>-macos-arm64.tar.gz
+grep phaeton-v<version>-macos-arm64.tar.gz SHA256SUMS
 ```
 
 Install:
 
 ```bash
-tar -xzf phaeton-<artifact>.tar.gz
+tar -xzf phaeton-v<version>-<artifact>.tar.gz
 sudo install -m 0755 phaeton /usr/local/bin/phaeton
 ```
 
@@ -120,9 +120,9 @@ Phaeton supports cross-compilation for multiple architectures to run on differen
 ```
 
 This will create release binaries in the `dist/` directory for:
-- **Cerbo GX (ARM v7)**: `phaeton-armv7-unknown-linux-gnueabihf.tar.gz`
-- **Linux ARM64**: `phaeton-aarch64-unknown-linux-gnu.tar.gz`
-- **macOS ARM64**: `phaeton-macos-arm64.tar.gz`
+- **Cerbo GX (ARM v7)**: `phaeton-v<version>-armv7-unknown-linux-gnueabihf.tar.gz`
+- **Linux ARM64**: `phaeton-v<version>-aarch64-unknown-linux-gnu.tar.gz`
+- **macOS ARM64**: `phaeton-v<version>-macos-arm64.tar.gz`
 
 #### GitHub Actions CI
 


### PR DESCRIPTION
…facts

- Enhanced `build.sh` and `Makefile` to derive version information from `Cargo.toml` or git tags, ensuring that generated tarballs are named with the version (e.g., `phaeton-v<version>-<target>.tar.gz`).
- Updated the README to reflect the new naming convention for release binaries, providing clearer instructions for users on how to download and verify the packages.
- Improved maintainability by centralizing version extraction logic in both build scripts.