### PR TITLE
v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "phaeton"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phaeton"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Phaeton - EV Charger Driver for Victron Venus OS"
 authors = ["Your Name <your.email@example.com>"]

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -429,12 +429,7 @@ impl DbusService {
             .at(&self.charger_path, charger)
             .await
             .map_err(|e| PhaetonError::dbus(format!("Register object failed: {}", e)))?;
-        // Add standard Properties interface so clients can use DBus Properties.Get
-        connection
-            .object_server()
-            .at(&self.charger_path, zbus::fdo::Properties)
-            .await
-            .map_err(|e| PhaetonError::dbus(format!("Register Properties failed: {}", e)))?;
+        // Note: org.freedesktop.DBus.Properties is provided implicitly by zbus for objects
         // Also register the root '/' as a BusItem tree provider similar to VeDbusRootExport
         let root = RootBus {
             shared: Arc::clone(&self.shared),

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -276,6 +276,14 @@ impl RootBus {
         out
     }
 
+    #[zbus(signal)]
+    async fn items_changed(
+        ctxt: &SignalContext<'_>,
+        changes: std::collections::HashMap<&str, std::collections::HashMap<&str, OwnedValue>>,
+    ) -> zbus::Result<()>;
+}
+
+impl RootBus {
     fn collect_subtree_map(
         &self,
         prefix: &str,
@@ -303,12 +311,6 @@ impl RootBus {
         }
         result
     }
-
-    #[zbus(signal)]
-    async fn items_changed(
-        ctxt: &SignalContext<'_>,
-        changes: std::collections::HashMap<&str, std::collections::HashMap<&str, OwnedValue>>,
-    ) -> zbus::Result<()>;
 }
 
 /// D-Bus service manager

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -928,11 +928,19 @@ impl BusItem {
         // Map writable items to driver commands
         match self.path.as_str() {
             "/Mode" => {
-                let m = sv.as_u64().unwrap_or(0) as u8;
+                let m = sv
+                    .as_u64()
+                    .map(|v| v as u8)
+                    .or_else(|| sv.as_i64().map(|v| v as u8))
+                    .unwrap_or(0);
                 let _ = shared.commands_tx.send(DriverCommand::SetMode(m));
             }
             "/StartStop" => {
-                let v = sv.as_u64().unwrap_or(0) as u8;
+                let v = sv
+                    .as_u64()
+                    .map(|x| x as u8)
+                    .or_else(|| sv.as_i64().map(|x| x as u8))
+                    .unwrap_or(0);
                 let _ = shared.commands_tx.send(DriverCommand::SetStartStop(v));
             }
             "/SetCurrent" => {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -376,12 +376,14 @@ impl AlfenDriver {
                 };
 
                 let (l1_p, l2_p, l3_p, p_total) = match power_regs {
-                    Some(v) if v.len() >= 8 => (
-                        decode_32bit_float(&v[0..2]).unwrap_or(0.0) as f64,
-                        decode_32bit_float(&v[2..4]).unwrap_or(0.0) as f64,
-                        decode_32bit_float(&v[4..6]).unwrap_or(0.0) as f64,
-                        decode_32bit_float(&v[6..8]).unwrap_or(0.0) as f64,
-                    ),
+                    Some(v) if v.len() >= 8 => {
+                        let p1 = decode_32bit_float(&v[0..2]).unwrap_or(0.0) as f64;
+                        let p2 = decode_32bit_float(&v[2..4]).unwrap_or(0.0) as f64;
+                        let p3 = decode_32bit_float(&v[4..6]).unwrap_or(0.0) as f64;
+                        let pt = decode_32bit_float(&v[6..8]).unwrap_or(0.0) as f64;
+                        let sanitize = |x: f64| if x.is_finite() { x } else { 0.0 };
+                        (sanitize(p1), sanitize(p2), sanitize(p3), sanitize(pt))
+                    }
                     _ => (0.0, 0.0, 0.0, 0.0),
                 };
 


### PR DESCRIPTION
### DBus root interface, change signals, and data normalization; version 0.5.1

### Overview
Align DBus behavior with Victron VeDbus for better GX UI compatibility and responsiveness. Adds a root `com.victronenergy.BusItem` interface, emits change signals, normalizes value types, and improves product naming. Bumps crate to 0.5.1.

### Key changes
- **RootBus at “/”**: Implement `com.victronenergy.BusItem` with `GetValue`, `GetText`, `GetItems`, aggregating values like VeDbusRootExport.
- **Intermediate nodes**: Register tree nodes as `com.victronenergy.BusItem` so `GetValue` on any path returns a subtree (VeDbusTreeExport behavior).
- **Change signals**: Emit per-path `PropertiesChanged(a{sv})` and root-level `ItemsChanged(a{sa{sv}})` to ensure GX UI updates promptly.
- **Typed properties**: Keep typed `com.victronenergy.evcharger` interface and standard `org.freedesktop.DBus.Properties`; remove manual Properties registration at `/`.
- **Product name**: Publish manufacturer-prefixed name when available (e.g., “Alfen NV EV Charger”) at `/ProductName`.
- **Power values**: Normalize `/Ac/L{1,2,3}/Power` and `/Ac/Power` to floats, sanitize non-finite values for consistent JSON and UI rendering.
- **Internal**: Refactor `BusItem` value handling; `SetValue` returns int status aligning with VeDbus contract.
- **Version**: `Cargo.toml` version bump to 0.5.1; lockfile updated.

### Compatibility
- **API**: Additive and aligned with VeDbus. Existing paths remain; improved signal semantics. Low risk to integrators.
- **Behavior**: GX UI should reflect value changes without reopening device pages.

### How to test
- On GX, restart service and confirm Firmware/Serial update live.
- Validate root aggregation:
  ```bash
  dbus -y com.victronenergy.evcharger.phaeton_0 / GetValue
  dbus -y com.victronenergy.evcharger.phaeton_0 / GetItems
  ```
- Verify `/ProductName` includes manufacturer when available.
- Check `/Ac/L{1,2,3}/Power` and `/Ac/Power` report consistent float values.

### Diff stats
- Files changed: `Cargo.toml`, `Cargo.lock`, `src/dbus.rs`, `src/driver.rs`
- 4 files changed, 260 insertions, 31 deletions (majority in `src/dbus.rs`).