### PR TITLE
Update Phaeton to version 0.8.0 and refactor router initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phaeton"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phaeton"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Phaeton - EV Charger Driver for Victron Venus OS"
 authors = ["Your Name <your.email@example.com>"]

--- a/src/web.rs
+++ b/src/web.rs
@@ -343,7 +343,7 @@ pub fn build_router(state: AppState) -> Router {
     #[cfg(feature = "openapi")]
     let openapi = ApiDoc::openapi();
 
-    let mut router = Router::new()
+    let router = Router::new()
         .route("/", get(|| async { Redirect::to("/ui/index.html") }))
         .route("/api/health", get(health))
         .route("/api/metrics", get(metrics))
@@ -389,9 +389,7 @@ pub fn build_router(state: AppState) -> Router {
         .layer(TraceLayer::new_for_http());
 
     #[cfg(feature = "openapi")]
-    {
-        router = router.merge(SwaggerUi::new("/docs").url("/openapi.json", openapi));
-    }
+    let router = router.merge(SwaggerUi::new("/docs").url("/openapi.json", openapi));
 
     router
 }


### PR DESCRIPTION
- Bump the version of the `phaeton` package in `Cargo.toml` and `Cargo.lock` to 0.8.0.
- Refactor the router initialization in `src/web.rs` to improve clarity by removing unnecessary mutable bindings and simplifying the merge of OpenAPI features.