### PR TITLE
Enhance date handling in Tibber API and client

### DIFF
--- a/src/controls.rs
+++ b/src/controls.rs
@@ -274,13 +274,16 @@ mod tests {
             timezone: "UTC".to_string(),
             ..crate::config::Config::default()
         };
-        // Build a schedule item that is active for the current weekday and minute
+        // Build a schedule item that covers [now, now+1min), handling hour wrap correctly
         let now = Utc::now();
         let weekday = now.weekday().num_days_from_monday() as u8;
-        let start_min = now.minute().saturating_sub(1);
-        let end_min = (now.minute() + 1).min(59);
-        let start = format!("{:02}:{:02}", now.hour(), start_min);
-        let end = format!("{:02}:{:02}", now.hour(), end_min);
+        let start_h = now.hour();
+        let start_m = now.minute();
+        let next = now + chrono::Duration::minutes(1);
+        let end_h = next.hour();
+        let end_m = next.minute();
+        let start = format!("{:02}:{:02}", start_h, start_m);
+        let end = format!("{:02}:{:02}", end_h, end_m);
         cfg.schedule.items.push(crate::config::ScheduleItem {
             active: true,
             days: vec![weekday],

--- a/src/tibber/api.rs
+++ b/src/tibber/api.rs
@@ -193,9 +193,9 @@ pub async fn get_plan_json(cfg: &crate::config::TibberConfig) -> Result<serde_js
         let end_at = if let Some(next) = upcoming.get(idx + 1) {
             next.starts_at.clone()
         } else {
-            // Fallback: add 1h to start
+            // Fallback: add 1h to start, preserving the original timezone offset
             match chrono::DateTime::parse_from_rfc3339(&p.starts_at) {
-                Ok(dt) => chrono::DateTime::<chrono::Utc>::from(dt)
+                Ok(dt) => dt
                     .checked_add_signed(chrono::Duration::hours(1))
                     .map(|v| v.to_rfc3339())
                     .unwrap_or_else(|| p.starts_at.clone()),


### PR DESCRIPTION
- Updated the fallback logic in `get_plan_json` to preserve the original timezone offset when adding one hour to the start time.
- Improved sorting of upcoming plans in `TibberClient` by using actual epoch time to correctly handle differing timezone offsets and daylight saving time, with a fallback to lexicographic order if parsing fails.

These changes improve the accuracy of date handling and sorting, enhancing the overall functionality and maintainability of the Tibber integration.