### PR TITLE
Add support for tar.gz package extraction in updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1315,7 @@ dependencies = [
  "axum",
  "chrono",
  "chrono-tz",
+ "flate2",
  "http-body-util",
  "once_cell",
  "pulldown-cmark",
@@ -1300,6 +1324,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tar",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",
@@ -2075,6 +2100,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3009,6 +3045,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xattr"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ zbus = { version = "5.10", default-features = false, features = ["tokio"] }
 reqwest = { version = "0.12", optional = true, default-features = false, features = ["json", "rustls-tls"] }
 pulldown-cmark = { version = "0.13", optional = true }
 ammonia = { version = "4.0", optional = true }
+tar = { version = "0.4", optional = true }
+flate2 = { version = "1", optional = true, default-features = false, features = ["rust_backend"] }
 
 # Date and time handling
 chrono = { version = "0.4", features = ["serde"] }
@@ -138,7 +140,8 @@ openapi = ["dep:utoipa", "dep:utoipa-swagger-ui", "dep:schemars"]
 tibber = ["dep:reqwest"]
 
 # Enable self-updater HTTP client and release notes rendering
-updater = ["dep:reqwest", "dep:pulldown-cmark", "dep:ammonia"]
+# Also include tar.gz extraction support to install full release packages
+updater = ["dep:reqwest", "dep:pulldown-cmark", "dep:ammonia", "dep:tar", "dep:flate2"]
 
 # Optional compression features for tower-http
 compression = ["tower-http/compression-br", "tower-http/compression-gzip"]

--- a/src/updater/package.rs
+++ b/src/updater/package.rs
@@ -1,0 +1,173 @@
+use crate::error::{PhaetonError, Result};
+use crate::logging::get_logger;
+use std::path::Path;
+
+#[cfg(feature = "updater")]
+use flate2::read::GzDecoder;
+#[cfg(feature = "updater")]
+use tar::Archive;
+
+#[cfg(feature = "updater")]
+pub fn is_gzip_file(path: &Path) -> Option<bool> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut magic = [0u8; 2];
+    if file.read_exact(&mut magic).is_ok() {
+        return Some(magic == [0x1F, 0x8B]);
+    }
+    None
+}
+
+#[cfg(feature = "updater")]
+pub fn apply_package_archive(archive_path: &Path) -> Result<()> {
+    let _logger = get_logger("updater");
+    let install_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .ok_or_else(|| PhaetonError::update("Cannot determine install directory"))?;
+
+    // Create staging directory alongside current install
+    let staging_dir = install_dir.join(format!("update-staging-{}", std::process::id()));
+    if staging_dir.exists() {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+    }
+    std::fs::create_dir_all(&staging_dir)?;
+
+    // Extract tar.gz
+    let file = std::fs::File::open(archive_path)?;
+    let dec = GzDecoder::new(file);
+    let mut ar = Archive::new(dec);
+    ar.unpack(&staging_dir)
+        .map_err(|e| PhaetonError::update(format!("Failed to extract package: {}", e)))?;
+
+    // Install webui directory if present
+    let src_webui = staging_dir.join("webui");
+    if src_webui.is_dir() {
+        let dest_webui = install_dir.join("webui");
+        replace_directory_atomic(&src_webui, &dest_webui)?;
+    }
+
+    // Install sample config if present (do not touch active config)
+    let src_sample = staging_dir.join("phaeton_config.sample.yaml");
+    if src_sample.is_file() {
+        let dest_sample = install_dir.join("phaeton_config.sample.yaml");
+        replace_file_atomic(&src_sample, &dest_sample, 0o644)?;
+    }
+
+    // Replace current executable last
+    let src_bin = staging_dir.join("phaeton");
+    if src_bin.is_file() {
+        // Ensure executable bit
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&src_bin)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&src_bin, perms)?;
+        }
+        super::GitUpdater::replace_current_executable(&src_bin)?;
+    } else {
+        return Err(PhaetonError::update(
+            "Package missing 'phaeton' binary after extraction",
+        ));
+    }
+
+    // Best-effort cleanup of staging
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    Ok(())
+}
+
+#[cfg(feature = "updater")]
+fn replace_directory_atomic(src_dir: &Path, dest_dir: &Path) -> Result<()> {
+    let logger = get_logger("updater");
+    let backup_dir = dest_dir.with_extension("old");
+
+    // Remove any previous backup
+    let _ = std::fs::remove_dir_all(&backup_dir);
+
+    if dest_dir.exists()
+        && let Err(e) = std::fs::rename(dest_dir, &backup_dir)
+    {
+        logger.warn(&format!(
+            "Failed to backup existing directory {}: {}",
+            dest_dir.display(),
+            e
+        ));
+        // Best-effort clean before copy fallback
+        let _ = std::fs::remove_dir_all(&backup_dir);
+    }
+
+    match std::fs::rename(src_dir, dest_dir) {
+        Ok(_) => {
+            let _ = std::fs::remove_dir_all(&backup_dir);
+            Ok(())
+        }
+        Err(rename_err) => {
+            // Fallback to recursive copy
+            logger.warn(&format!(
+                "Directory rename failed: {}. Falling back to copy.",
+                rename_err
+            ));
+            if !dest_dir.exists() {
+                std::fs::create_dir_all(dest_dir)?;
+            }
+            copy_dir_recursive(src_dir, dest_dir)?;
+            // Cleanup
+            let _ = std::fs::remove_dir_all(src_dir);
+            let _ = std::fs::remove_dir_all(&backup_dir);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "updater")]
+fn copy_dir_recursive(from: &Path, to: &Path) -> Result<()> {
+    for entry in std::fs::read_dir(from)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = to.join(entry.file_name());
+        if src_path.is_dir() {
+            std::fs::create_dir_all(&dst_path)?;
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "updater")]
+fn replace_file_atomic(src: &Path, dest: &Path, mode: u32) -> Result<()> {
+    let backup = dest.with_extension("old");
+    let _ = std::fs::remove_file(&backup);
+    if dest.exists() {
+        let _ = std::fs::rename(dest, &backup);
+    }
+    match std::fs::rename(src, dest) {
+        Ok(_) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(dest)?.permissions();
+                perms.set_mode(mode);
+                std::fs::set_permissions(dest, perms)?;
+            }
+            let _ = std::fs::remove_file(&backup);
+            Ok(())
+        }
+        Err(_) => {
+            // Fallback to copy
+            std::fs::copy(src, dest)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(dest)?.permissions();
+                perms.set_mode(mode);
+                std::fs::set_permissions(dest, perms)?;
+            }
+            let _ = std::fs::remove_file(src);
+            let _ = std::fs::remove_file(&backup);
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
- Introduced functionality to handle tar.gz files during the update process, allowing for the extraction and installation of package contents.
- Created a new module for package handling, including methods for checking gzip file types and applying package archives.
- Updated the updater logic to differentiate between single binary and archive installations, enhancing the update mechanism's flexibility.

These changes improve the updater's capability to manage complex package formats, ensuring a smoother installation experience for users.